### PR TITLE
Добавляем анимацию блоков

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -334,7 +334,7 @@
               <p>&laquo;Соня&raquo; может отвечать только&nbsp;Да или Нет</p>
             </li>
           </ol>
-          <a href="#game" class="rules__link btn">Погнали!</a>
+          <a href="#game" class="rules__link btn"><span>Погнали!</span></a>
         </div>
       </div>
       <div class="screen__disclaimer">

--- a/source/index.html
+++ b/source/index.html
@@ -322,15 +322,23 @@
           </div>
           <ol class="rules__list">
             <li class="rules__item">
+              <div class="rules__circle"></div>
+              <div class="rules__circle-text">1</div>
               <p>Тебе отводится <br>5&nbsp;минут</p>
             </li>
             <li class="rules__item">
+              <div class="rules__circle"></div>
+              <div class="rules__circle-text">2</div>
               <p>Задавай любые вопросы в&nbsp;текстовом поле</p>
             </li>
             <li class="rules__item">
+              <div class="rules__circle"></div>
+              <div class="rules__circle-text">3</div>
               <p>Нажимай кнопку &laquo;Узнать&raquo;, чтобы получить ответ</p>
             </li>
             <li class="rules__item">
+              <div class="rules__circle"></div>
+              <div class="rules__circle-text">4</div>
               <p>&laquo;Соня&raquo; может отвечать только&nbsp;Да или Нет</p>
             </li>
           </ol>

--- a/source/scss/blocks/rules.scss
+++ b/source/scss/blocks/rules.scss
@@ -179,6 +179,8 @@
 
   p {
     margin: 0;
+    transform: translateX(40px);
+    opacity: 0;
 
     @media (max-width: $tablet) and (orientation: portrait) {
       min-height: calc(1.4rem * 2.2);
@@ -186,10 +188,61 @@
   }
 }
 
+@for $i from 1 through 4 {
+  .rules__item:nth-child(#{$i}) {
+    &::before {
+      transform: scale(0);
+      animation: rulesCircleAnimation cubic-bezier(.41, .28, .13, 1.5) 0.5s forwards;
+      animation-delay: #{$i * 0.2}s;
+
+      @keyframes rulesCircleAnimation {
+        to {
+          transform: scale(1);
+        }
+      }
+    }
+
+    p {
+      animation: rulesText 1s forwards;
+      animation-delay: #{$i * 0.2}s;
+
+      @keyframes rulesText {
+        to {
+          transform: translateX(0);
+          opacity: 1;
+        }
+      }
+    }
+
+  }
+}
+
 .rules__link {
   position: absolute;
   bottom: 6rem;
   right: 5.6rem;
+  transform-origin: center right;
+  width: 10px;
+  animation: rulesLink 1s forwards;
+
+  @keyframes rulesLink {
+    to {
+      width: 140px;
+    }
+  }
+
+  span {
+    opacity: 0;
+    animation: rulesLinkText 0.3s forwards 1s;
+
+    @keyframes rulesLinkText {
+      to {
+        opacity: 1;
+      }
+    }
+  }
+
+
 
   @media (min-width: $stop-scaling) {
     bottom: 60px;

--- a/source/scss/blocks/rules.scss
+++ b/source/scss/blocks/rules.scss
@@ -144,21 +144,13 @@
     font-size: 1.2rem;
   }
 
-  &::before {
-    content: counter(li);
-    counter-increment: li;
+  .rules__circle-text,
+  .rules__circle {
     position: absolute;
     top: 0;
     left: 0;
     width: 4.5rem;
     height: 4.5rem;
-    font-family: $font-alt;
-    font-weight: 400;
-    font-size: 2.4rem;
-    background-color: $c-purple;
-    border-radius: 50%;
-    line-height: 5rem;
-    text-align: center;
 
     @media (max-width: $tablet) and (orientation: portrait) {
       top: 1rem;
@@ -177,6 +169,21 @@
     }
   }
 
+  .rules__circle {
+    background-color: $c-purple;
+    border-radius: 50%;
+    transform: scale(0);
+  }
+
+  .rules__circle-text {
+    font-family: $font-alt;
+    font-weight: 400;
+    font-size: 2.4rem;
+    line-height: 5rem;
+    text-align: center;
+    opacity: 0;
+  }
+
   p {
     margin: 0;
     transform: translateX(40px);
@@ -190,8 +197,17 @@
 
 @for $i from 1 through 4 {
   .rules__item:nth-child(#{$i}) {
-    &::before {
-      transform: scale(0);
+    .rules__circle-text {
+      animation: rulesCircleText 1s forwards 0.5s;
+
+      @keyframes rulesCircleText {
+        to {
+          opacity: 1;
+        }
+      }
+    }
+
+    .rules__circle {
       animation: rulesCircleAnimation cubic-bezier(.41, .28, .13, 1.5) 0.5s forwards;
       animation-delay: #{$i * 0.2}s;
 
@@ -213,7 +229,6 @@
         }
       }
     }
-
   }
 }
 
@@ -227,7 +242,7 @@
 
   @keyframes rulesLink {
     to {
-      width: 140px;
+      width: 18rem;
     }
   }
 


### PR DESCRIPTION
Не понял только как сделать opacity к цифрам внутри появляющихся кругов .rules__item::before . Получается, что сами круги должны всегда быть видимыми, но менять свой радиус, в то время, как цифры внутри должны появляться от опасити 0 до 1. Возможно ли такое сделать вообще? Единственный вариант, который я вижу сейчас - это изменить разметку, например для круга сделать див, а текст, например, обернуть в span и тогда можно отдельно анимировать круг, отдельно текст. 

---
:mortar_board: [Добавляем анимацию блоков](https://up.htmlacademy.ru/animation/1/user/1741957/tasks/6)

:boom: https://htmlacademy-animation.github.io/1741957-magic-vacation-1/5/